### PR TITLE
Add case study collection

### DIFF
--- a/_case-study/case-study-1
+++ b/_case-study/case-study-1
@@ -1,0 +1,9 @@
+---
+layout: case-study
+permalink: /toolkit/case-study/test1/
+title: Case Study 1
+description: This is a sample case study.
+image: /assets/img/toolkit-images/home-case-studies2.gif
+url: /case-study/case-study-1
+---
+

--- a/_case-study/case-study-2
+++ b/_case-study/case-study-2
@@ -1,0 +1,8 @@
+---
+layout: case-study
+permalink: /toolkit/case-study/test2/
+title: Case Study 2
+description: This is another sample case study.
+image: /assets/img/toolkit-images/home-case-studies2.gif
+url: /case-study/case-study-2
+---

--- a/_case-study/case-study-3
+++ b/_case-study/case-study-3
@@ -1,0 +1,8 @@
+---
+layout: case-study
+permalink: /toolkit/case-study/test3/
+title: Case Study 3
+description: This is another sample case study.
+image: /assets/img/toolkit-images/home-case-studies2.gif
+url: /case-study/case-study-3
+---

--- a/_case-study/case-study-4
+++ b/_case-study/case-study-4
@@ -1,0 +1,8 @@
+---
+layout: case-study
+permalink: /toolkit/case-study/test4/
+title: Case Study 4
+description: This is another sample case study.
+image: /assets/img/toolkit-images/home-case-studies2.gif
+url: /case-study/case-study-4
+---

--- a/_case-study/case-study-5
+++ b/_case-study/case-study-5
@@ -1,0 +1,8 @@
+---
+layout: case-study
+permalink: /toolkit/case-study/test5/
+title: Case Study 5
+description: This is another sample case study.
+image: /assets/img/toolkit-images/home-case-studies2.gif
+url: /case-study/case-study-5
+---

--- a/_config.yml
+++ b/_config.yml
@@ -112,6 +112,8 @@ collections:
     output: true
   how-to-steps:
     output: true
+  case-study:
+    output: true
 
 
 wds-version: 1.4.2

--- a/_data/toolkit-navbar.yml
+++ b/_data/toolkit-navbar.yml
@@ -13,8 +13,8 @@ assigned:
         show_in_footer: false
     -
         text: Case Studies
-        href: pages/about.md
-        permalink: /about/
+        href: toolkit/toolkit-case-studies.md
+        permalink: /toolkit/case-study/
         show_in_menu: true
         show_in_footer: false
     -

--- a/_layouts/case-study.html
+++ b/_layouts/case-study.html
@@ -1,0 +1,8 @@
+---
+layout: toolkit-base
+---
+
+
+<section class="usa-grid usa-section">
+    <h1 class="page-heading">{{ page.title }}</h1>
+</section>

--- a/pages/toolkit/toolkit-case-studies.md
+++ b/pages/toolkit/toolkit-case-studies.md
@@ -1,0 +1,34 @@
+---
+layout: toolkit-base
+permalink: /toolkit/case-study
+title: Case Studies
+---
+
+
+<div class="usa-section usa-grid">
+
+	<h2>{{ page.title }}</h2>
+
+{% for item in site.case-study %}
+	{% assign third = forloop.index | modulo: 3 %} {% if third == 0 %}
+		<div class="usa-width-one-third usa-end-row">
+				{% else %}
+				<div class="usa-width-one-third">
+						{% endif %}
+						<article>
+								<a href="{{ item.url | prepend: site.baseurl }}">
+									<img src="{{ item.image }}">
+								</a>
+								<div class="infos">
+										<h3 class="title">{{ item.title }}</h3>
+										<p class="txt">
+												{{ item.description }}...
+										</p>
+										<p>
+											<a href="{{ item.url | prepend: site.baseurl }}" class="details">read more</a>
+										</p>
+								</div>
+						</article>
+		</div>
+{% endfor %}
+</div>

--- a/pages/toolkit/toolkit-home.md
+++ b/pages/toolkit/toolkit-home.md
@@ -3,6 +3,7 @@ layout: toolkit-base
 permalink: /toolkit/
 title: Federal Crowdsourcing and Citizen Science Toolkit
 how-to-link: /toolkit/howto/
+case-study-link: /toolkit/case-study/
 banner-heading: Find Federally Sponsored Projects
 banner-text: The Federal Crowdsourcing and Citizen Science Catalog provides a government-wide listing of citizen science and crowdsourcing projects by agency. Projects submitted to the catalog are validated for agency involvement by federal employees.
 banner-button-text: view the catalog
@@ -34,7 +35,7 @@ banner-button-link: https://ccsinventory.wilsoncenter.org/
 
 
 	    <article class="card usa-width-one-third">
-	      <a href="#">
+	      <a href="{{ page.case-study-link | prepend: site.baseurl }}">
 	      <div class="card-image" style="background-image: url(/assets/img/toolkit-images/home-case-studies2.gif); min-height: 200px">
 	      </div>
 	    </a>
@@ -42,7 +43,7 @@ banner-button-link: https://ccsinventory.wilsoncenter.org/
 	        <h3 class="card-description">Case Study Overview</h3>
 	        <p class="card-summary">Case studies in this toolkit serve as models and provide success stories and challenges to consider while planning a project. You can browse through agency case studies to get ideas for a project of your own.</p>
 	      </div>
-	      <a class="card-read" href="{{ project.url | prepend: site.baseurl }}">
+	      <a class="card-read" href="{{ page.case-study-link | prepend: site.baseurl }}">
 	        Browse Case Studies
 	        <span class="usa-sr-only">about {{ project.title }}</span>
 	      </a>


### PR DESCRIPTION
Changes proposed:
- Create a new 'case study' collection in config.yml
- Add _case-study folder to house the collection
- Add toolkit/toolkit-case-studies.md page to list all the case studies in the collection
- Add 5 test case studies. Each will be at toolkit/case-study/test1, ..test 2, etc.
- Add new case study layout to _layouts. This is just a base template which will display the case study title. Needs customized. 
- Update toolkit/home to link the nav and case study card to the new case study list page

AFTER: 
<img width="1226" alt="screen shot 2017-11-22 at 11 56 58 am" src="https://user-images.githubusercontent.com/2197515/33140394-d954f564-cf7d-11e7-91b6-ef760b78e0e8.png">
