### PR TITLE
make links relative instead of hard-coded to the production URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           <img class="usa-footer-logo-img" src="{{ site.footer.image | prepend: site.baseurl }}" alt=" GSA Logo image">
         </a>
         {% endif %}
-        <a href="https://www.citizenscience.gov">
+        <a href="{{ site.url }}">
           <img class="footer-logo" src="{{ site.baseurl }}/assets/img/logo-main_transparent.png" alt="www.citizenscience.gov">
         </a>
         {% if site.footer.text %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,7 @@
       <button class="usa-menu-btn">Menu</button>
       <div class="usa-logo" id="logo">
         <em class="usa-logo-text">
-          <a href="https://www.citizenscience.gov" accesskey="1" title="Home" aria-label="Home">
+          <a href="{{ site.url }}" accesskey="1" title="Home" aria-label="Home">
           {% if site.logo %}
             <img src="{{ site.logo | prepend: site.baseurl }}" alt="{{ site.title }}">
           {% else %}

--- a/_projects/citizen-science-catalog.md
+++ b/_projects/citizen-science-catalog.md
@@ -4,7 +4,7 @@ title: Federal Crowdsourcing and Citizen Science Catalog
 short_title: Explore Projects
 description: This searchable database provides a government-wide listing of citizen science and crowdsourcing projects designed to improve cross-agency collaboration, reveal opportunities for new high-impact projects, and make it easier for volunteers to find out about projects they can join.
 permalink: /about/catalog/
-read-more-link: https://www.citizenscience.gov/about/catalog/
+read-more-link: /about/catalog/
 tags: project
 image: /assets/img/project-images/catalog.jpg
 link-out: /catalog/
@@ -19,10 +19,8 @@ link-out: /catalog/
   </div>
 </div>
 
-This database provides a government-wide listing of citizen science and crowdsourcing projects by agency. 
+This database provides a government-wide listing of citizen science and crowdsourcing projects by agency.
 
 It is designed to improve cross-agency collaboration, reveal opportunities for new and high-impact projects, and make it easier for volunteers to find projects in which they can participate. Projects submitted to the catalog are validated for agency involvement by federal employees.
 
 <a href="{{ site.baseurl }}/catalog/">Visit the Catalog here</a>
-
-

--- a/_projects/citizen-science-community.md
+++ b/_projects/citizen-science-community.md
@@ -7,7 +7,7 @@ permalink: /about/community-of-practice/
 read-more-link: https://www.digitalgov.gov/communities/crowdsourcing-and-citizen-science/
 tags: project
 image: /assets/img/project-images/community.jpg
-link-out: https://www.citizenscience.gov/about/community-of-practice/
+link-out: /about/community-of-practice/
 ---
 ## Welcome to Our Community!
 #### There are two primary groups within the federal government working to advance crowdsourcing and citizen science use and practice. These are:

--- a/pages/catalog-add-project.html
+++ b/pages/catalog-add-project.html
@@ -6,14 +6,14 @@ permalink: /catalog/add-project/
     <div class="usa-alert usa-alert-info" >
         <div class="usa-alert-body">
             <h3 class="usa-alert-heading">Please Note</h3>
-            <p class="usa-alert-text">Projects must be conducted by or have support (funding or in-kind) from at least one U.S. federal agency to appear in the <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/catalog/#">catalog</a>.</p>
+            <p class="usa-alert-text">Projects must be conducted by or have support (funding or in-kind) from at least one U.S. federal agency to appear in the <a target="_blank" rel="noopener" href="/catalog/#">catalog</a>.</p>
         </div>
     </div>
     <br>
     <p><span class="catalog-form-add">To add a new project:</span>
         <ol>
-            <li>Please check that the project is not already in the <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/catalog/#">catalog</a> by using the search feature.</li>
-            <li>If it is not already in the <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/catalog/#">catalog</a>, enter and submit project information through the online <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLScLD3Y4jLBEtIa466gIKAg8reXdKvzzPFImFrt-BMKF_wIOBQ/viewform">submission form</a>.</li>
+            <li>Please check that the project is not already in the <a target="_blank" rel="noopener" href="/catalog/#">catalog</a> by using the search feature.</li>
+            <li>If it is not already in the <a target="_blank" rel="noopener" href="/catalog/#">catalog</a>, enter and submit project information through the online <a target="_blank" rel="noopener" href="https://docs.google.com/forms/d/e/1FAIpQLScLD3Y4jLBEtIa466gIKAg8reXdKvzzPFImFrt-BMKF_wIOBQ/viewform">submission form</a>.</li>
         </ol>
     </p>
     <p><span class="catalog-form-add">To edit a project already in the catalog:</span>
@@ -22,6 +22,6 @@ permalink: /catalog/add-project/
             <li>State the name of the project and list the edits you want made in the body of the email.</li>
         </ol>
     </p>
-    <p>Please be aware that each project submission or requested edit needs to be verified by the <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/agency-community/#">Crowdsourcing and Citizen Science Coordinator(s)</a> from the supporting agency(ies) before it is added to the <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/catalog/#">catalog</a>. This process may take a couple of weeks.</p>  
-    <p>Thank you for the interest in helping expand and improve the project listings in our <a target="_blank" rel="noopener" href="https://www.citizenscience.gov/catalog/#">catalog</a>!</p> 
+    <p>Please be aware that each project submission or requested edit needs to be verified by the <a target="_blank" rel="noopener" href="/agency-community/#">Crowdsourcing and Citizen Science Coordinator(s)</a> from the supporting agency(ies) before it is added to the <a target="_blank" rel="noopener" href="/catalog/#">catalog</a>. This process may take a couple of weeks.</p>  
+    <p>Thank you for the interest in helping expand and improve the project listings in our <a target="_blank" rel="noopener" href="/catalog/#">catalog</a>!</p> 
 </div>


### PR DESCRIPTION
# Story

As a Developer,
I want to be able to navigate the site during development
And not be redirected to the Production version of the site unintentionally