### PR TITLE
Fix code scanning alert no. 25: Incomplete string escaping or encoding

### DIFF
--- a/assets/vendor/uswds-1.4.2/js/uswds.js
+++ b/assets/vendor/uswds-1.4.2/js/uswds.js
@@ -1029,7 +1029,8 @@ var trim = String.prototype.trim ? function (str) {
 };
 
 var queryById = function queryById(id) {
-  return this.querySelector('[id="' + id.replace(/"/g, '\\"') + '"]');
+  id = id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return this.querySelector('[id="' + id + '"]');
 };
 
 module.exports = function resolveIds(ids, doc) {


### PR DESCRIPTION
Fixes [https://github.com/GSA/citizenscience.gov/security/code-scanning/25](https://github.com/GSA/citizenscience.gov/security/code-scanning/25)

To fix the problem, we need to ensure that backslashes in the `id` variable are properly escaped before using it in the `querySelector` call. This can be done by adding an additional `replace` call to escape backslashes. The best way to fix this without changing existing functionality is to modify the `queryById` function to include this additional escaping.
